### PR TITLE
Fix link  to about in header and update/remove outbound links

### DIFF
--- a/app/views/home/contact.html.erb
+++ b/app/views/home/contact.html.erb
@@ -1,5 +1,5 @@
 <div class="untabbed-content">
   <h1>Contact Us</h1>
   <p>If you have any questions or comments about VideoPaper Builder<span class="reg">&reg;</span>, send an email to <a href="mailto:videopaper&#64;concord.org" title="Contact the Concord Consortium">videopaper&#64;concord.org</a>.</p>
-  <p>Please note that use of VideoPaper Builder<span class="reg">&reg;</span> 4.0 is currently limited to a small trial group. If you are interested in using VideoPaper Builder<span class="reg">&reg;</span> 4.0 for your own project, please send an email request to <a href="mailto:videopaper&#64;concord.org" title="Contact the Concord Consortium">videopaper&#64;concord.org</a>. VideoPaper Builder 3 is available for general use. You can download it from the <a href="http://vpb.archive.concord.org/" title="VideoPaper Builder Archive">VideoPaper Builder archive site</a>.</p>
+  <p>Please note that use of VideoPaper Builder<span class="reg">&reg;</span> 4.0 is currently limited to a small trial group. If you are interested in using VideoPaper Builder<span class="reg">&reg;</span> 4.0 for your own project, please send an email request to <a href="mailto:videopaper&#64;concord.org" title="Contact the Concord Consortium">videopaper&#64;concord.org</a>.</p>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
           <div class="left_curve">
             <div class="right_curve">
               <ul>
-                <li><a href="/about/index.html">About VPB</a></li>
-                <li class="last"><a href="http://www.concord.org/" title="The Concord Consortium">The&nbsp;Concord&nbsp;Consortium</a></li>
+                <li><a href="/about">About VPB</a></li>
+                <li class="last"><a href="https://concord.org/" title="The Concord Consortium">The&nbsp;Concord&nbsp;Consortium</a></li>
               </ul>
             </div>
           </div>
@@ -88,23 +88,22 @@
         <h3>VideoPaper Builder<span class="reg">&reg;</span></h3>
         <ul>
           <li><a href="/" title="VideoPaper Builder&reg;">VPB Home</a></li>
-          <li><a href="/about/" title="About VideoPaper Builder&reg;">About VPB</a></li>
-          <li><a href="/contact/" title="Contact the Concord Consortium">Contact Us</a></li>
-          <li><a href="http://vpb.archive.concord.org/" title="Archive of the Previous VPB Website">Archive Site</a></li>
+          <li><a href="/about" title="About VideoPaper Builder&reg;">About VPB</a></li>
+          <li><a href="/contact" title="Contact the Concord Consortium">Contact Us</a></li>
         </ul>
       </div>
       <div class="col2">
         <h3>The Concord Consortium</h3>
         <ul>
-          <li><a href="http://www.concord.org/" title="The Concord Consortium">Home</a></li>
-          <li><a href="http://blog.concord.org/" title="The Concord Consortium Blog">Blog</a></li>
-          <li><a href="http://www.concord.org/projects/" title="The Concord Consortium's Projects">Our Work</a></li>
-          <li><a href="http://www.concord.org/research-publications/" title="The Concord Consortium's Publications">Publications</a></li>
-          <li><a href="http://www.concord.org/about" title="About the Concord Consortium">About Us</a></li>
+          <li><a href="https://concord.org/" title="The Concord Consortium">Home</a></li>
+          <li><a href="https://concord.org/blog/" title="The Concord Consortium Blog">Blog</a></li>
+          <li><a href="https://concord.org/our-work/research-projects/" title="The Concord Consortium's Projects">Our Work</a></li>
+          <li><a href="https://concord.org/our-work/publications/" title="The Concord Consortium's Publications">Publications</a></li>
+          <li><a href="https://concord.org/about" title="About the Concord Consortium">About Us</a></li>
         </ul>
       </div>
       <div id="cc-logo">
-        <a href="http://www.concord.org/" title="The Concord Consortium"><img src="/images/cc-logo.png" alt="The Concord Consortium" /></a>
+        <a href="https://concord.org/" title="The Concord Consortium"><img src="/images/cc-logo.png" alt="The Concord Consortium" /></a>
       </div>
     </div>
   </div>

--- a/app/views/share_mailer/share_email.html.erb
+++ b/app/views/share_mailer/share_email.html.erb
@@ -11,6 +11,6 @@
       <p><%= @note%></p>
     <% end %>
     Enjoy the VideoPaper!<br/>
-    -The VideoPaper Team at <%= link_to 'Concord Consortium', 'http://concord.org'%>
+    -The VideoPaper Team at <%= link_to 'Concord Consortium', 'https://concord.org'%>
   </body>
 </html>


### PR DESCRIPTION
- Changes about/index.html to about in header
- Changes all http://www.concord.org to https://concord.org
- Updates to new links for blog, research projects and publications
- Removes liks to vpb.archive.concord.org as it 404s