### PR TITLE
Add some capybara debugging tools

### DIFF
--- a/docker/dev/docker-compose-expose-capybara.yml
+++ b/docker/dev/docker-compose-expose-capybara.yml
@@ -1,0 +1,14 @@
+# Publish the capybara port. This makes it possible to run chrome driver on the host
+
+version: '3'
+services:
+  app:
+    ports:
+      - "43447:43447"
+
+# Note about defined port:
+# When running features in non-headless mode the app communicates with chromedriver on
+#  the host machine (at port 9515). Then, on the host machine, Chrome needs to make a
+# connection back into the Docker container at the port that the test server is running on.
+# In this case we've chosen port 43447. This port is not used elsewhere so should not
+# have any port conflicts.

--- a/spec/spec_helper_common.rb
+++ b/spec/spec_helper_common.rb
@@ -3,5 +3,4 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
 
 CapybaraInitializer.configure do |config|
   config.headless = ENV.fetch('HEADLESS', true) != 'false'
-  config.context = ENV['DOCKER'].present? ? :docker : nil
 end

--- a/spec/support/capybara_initializer.rb
+++ b/spec/support/capybara_initializer.rb
@@ -8,6 +8,9 @@ class CapybaraInitializer
   end
 
   def call
+    # To enable more debugging from WebDriver uncomment this line
+    # Selenium::WebDriver.logger.level = :debug
+
     # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
     # order to ease the transition to Capybara we set the default here. If you'd
     # prefer to use XPath just remove this line and adjust any selectors in your
@@ -20,7 +23,7 @@ class CapybaraInitializer
 
     # Add some Capybara config if we are running
     # Chrome on the docker host machine.
-    if !headless? && docker?
+    if !headless?
       Capybara.server_host = '0.0.0.0'
       Capybara.server_port = '43447'
     end
@@ -51,9 +54,9 @@ class CapybaraInitializer
       # driver_opts can be used to pass options to chromedriver, for example --log-level=DEBUG
       # this approach is deprecated though so you might need to use the newer approach
       # in the future
-      # driver_opts: [ '--log-level=DEBUG']
+      # driver_opts: [ '--log-level=DEBUG', "--log-path=chromedriver.log"]
      }.tap do |a|
-      a[:url] = 'http://host.docker.internal:9515/' if !headless? && docker?
+      a[:url] = 'http://host.docker.internal:9515/' if !headless?
     end
   end
 
@@ -75,9 +78,5 @@ class CapybaraInitializer
     %w(no-sandbox disable-gpu window-size=1440,900).tap do |a|
       a << 'headless' if headless?
     end
-  end
-
-  def docker?
-    context == :docker
   end
 end


### PR DESCRIPTION
Running the tests with the expose-capybara overlay, and HEADLESS=false will
attempt to connect to a chromedriver running on the local machine.
This also removes the check for docker. Additionally the HOST name for the local host needs to be changed when running on linux.