### PR TITLE
Fix admin issues

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,8 +1,15 @@
 class AdminsController < ApplicationController
   before_action :authenticate_admin!
+
   def index
     @admins = Admin.all
     @users = User.all
+  end
+
+  def destroy
+    @admin = Admin.find(params[:id])
+    @admin.destroy
+    redirect_to(admins_path,:notice=>"Admin: #{@admin.name} was removed.")
   end
 
   # NOTE: this is only used by admins so it is safe to lookup by user id instead

--- a/db/migrate/20200413160307_fix_admin_devise_recoverable.rb
+++ b/db/migrate/20200413160307_fix_admin_devise_recoverable.rb
@@ -1,0 +1,11 @@
+class FixAdminDeviseRecoverable < ActiveRecord::Migration[6.0]
+  def up
+    change_table :admins do |t|
+      t.datetime :reset_password_sent_at
+    end
+  end
+
+  def down
+    remove_column :admins, :reset_password_sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_013855) do
+ActiveRecord::Schema.define(version: 2020_04_13_160307) do
 
   create_table "admins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2020_03_30_013855) do
     t.integer "invited_by_id"
     t.string "invited_by_type"
     t.datetime "invitation_created_at"
+    t.datetime "reset_password_sent_at"
     t.index ["confirmation_token"], name: "index_admins_on_confirmation_token", unique: true
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["invitation_token"], name: "index_admins_on_invitation_token"

--- a/spec/controllers/admins_controller_spec.rb
+++ b/spec/controllers/admins_controller_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe AdminsController do
+
+  before(:each) do
+    @admin = FactoryBot.create(:admin)
+    @admin2 = FactoryBot.create(:admin)
+    @user = FactoryBot.create(:user)
+    sign_in @admin
+  end
+
+  it "should support destroy" do
+    delete :destroy, params: { :id => @admin2.id }
+    expect(response.status).to eq 302
+    expect(response).to redirect_to admins_path()
+  end
+
+  it "should support index" do
+    get :index
+    expect(response.status).to eq 200
+  end
+
+  it "should support accept_user_invitation" do
+    patch :accept_user_invitation, params: {:user => {:id => @user.id }}
+    expect(response.status).to eq 302
+    expect(response).to redirect_to admin_console_url()
+  end
+
+end


### PR DESCRIPTION
- Added reset_password_sent_at to admins table.  This was missing and used internally in devise which caused the invite to fail when the password was updated.  This was fixed 7 years ago in the users table but not in the admins table.
- Added missing destory to admins controller