### PR TITLE
AWS is requiring sig v4 now

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-ses (0.6.0)
+    aws-ses (0.7.0)
       builder
       mail (> 2.2.5)
       mime-types
@@ -189,7 +189,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.4)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)

--- a/config/initializers/amazon_ses.rb
+++ b/config/initializers/amazon_ses.rb
@@ -1,4 +1,5 @@
 # Use new AWS::SES mailer method from 'aws-ses' gem
 ActionMailer::Base.add_delivery_method :ses, AWS::SES::Base,
     access_key_id: ENV['SES_KEY'],
-    secret_access_key: ENV['SES_SECRET']
+    secret_access_key: ENV['SES_SECRET'],
+    signature_version: 4


### PR DESCRIPTION
The newer version of this gem lets us set signature_version 4 explicitly